### PR TITLE
Add a new flag to allow redis reconnection

### DIFF
--- a/bin/qless-js-worker.js
+++ b/bin/qless-js-worker.js
@@ -43,6 +43,7 @@ commander
   .option('-i, --interval <n>', 'Polling interval in seconds [default 60]', parseFloat)
   .option('-q, --queue <name>', 'Add a queue to work on', collect, [])
   .option('-v, --verbose', 'Increase logging level', increaseVerbosity, 0)
+  .option('-y, --allow-connection-retry', 'Allow reconnection after redis connection errors')
   .option('-a, --allow-paths', 'Allow paths for job class names')
   .option('-m, --max-memory <max>', 'Maximum memory each process can consume', 'Infinity')
   .option('-t, --set-tmpdir', 'Set tmpdir to be qless worker process workdir')
@@ -74,6 +75,7 @@ const config = {
   clientConfig: {
     url: options.redis,
     hostname: options.name,
+    allowConnectionRetry: options.allowConnectionRetry,
   },
   queueNames: options.queue,
   interval: (options.interval || 60) * 1000,

--- a/lib/client.js
+++ b/lib/client.js
@@ -18,6 +18,7 @@ class Client {
 
   constructor(config) {
     this.config = config;
+    this.config.retry_strategy = this.config.allowConnectionRetry ? this.retryStrategy : undefined;
     this.redis = redis.createClient(config);
     this.path = path.join(__dirname, 'qless-core', 'qless.lua');
     this.sha = null;
@@ -33,6 +34,14 @@ class Client {
   // Use a client only for the duration of handler
   static using(config, handler) {
     return Promise.using(Client.disposer(config), handler);
+  }
+
+  retryStrategy(options) {
+    if (options.attempt > 5) {
+      return undefined;
+    }
+
+    return 5000;
   }
 
   // Close this client

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inst/qless-js",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",


### PR DESCRIPTION
Connection to redis might get interrupted if there is a timeout or a network issue. In these cases, qless could try reestablishing the connection instead of terminating the whole process.

References SOS-2827