### PR TITLE
Avoid cyclically mutating promise in heartbeat wrapper

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -7,6 +7,8 @@ const Path = require('path');
 const logger = require('./logger.js');
 const asArray = require('./util.js').asArray;
 
+require('fs/promises').writeFile(Path.join('/tmp', 'loaded.txt'), '\n');
+
 class BaseJob {
 
   constructor(client, config) {
@@ -299,6 +301,19 @@ class Job extends BaseJob {
     }
 
     scheduleHeartbeat();
+    try {
+      console.log("QLESS-TEST", {
+        stack: new Error().stack,
+        getActiveResourcesInfo: process.getActiveResourcesInfo(),
+        ttl: this.getTtl(),
+        forkEnabled: this.forkEnabled(),
+        promise: promise,
+        wrappedPromise: wrappedPromise,
+        this_: this,
+      });
+    } catch (error) {
+      logger.error(error);
+    }
     return wrappedPromise.finally(() => clearTimeout(scheduledHeartBeat));
   }
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -270,12 +270,17 @@ class Job extends BaseJob {
    * expire.
    */
   heartbeatUntilPromise(promise, padding) {
+    // The promise is wrapped in Bluebird to ensure it adheres to the expected API
+    const wrappedPromise = Promise.resolve(promise);
     // Default to 10 seconds
     padding = padding || 10;
 
     let scheduledHeartBeat = undefined;
 
     const scheduleHeartbeat = () => {
+      if (!wrappedPromise.isPending()) {
+        return;
+      }
       // Heartbeat when `padding` seconds remain (converted to milliseconds)
       const interval = (this.getTtl() - padding) * 1000;
       scheduledHeartBeat = setTimeout(doHeartbeat, interval);
@@ -294,7 +299,7 @@ class Job extends BaseJob {
     }
 
     scheduleHeartbeat();
-    return promise.finally(() => clearTimeout(scheduledHeartBeat));
+    return wrappedPromise.finally(() => clearTimeout(scheduledHeartBeat));
   }
 
   fail(group, message) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -270,23 +270,31 @@ class Job extends BaseJob {
    * expire.
    */
   heartbeatUntilPromise(promise, padding) {
-    // The promise is wrapped in Bluebird to ensure it adheres to the expected API
-    const wrappedPromise = Promise.resolve(promise);
     // Default to 10 seconds
     padding = padding || 10;
 
-    const poll = () => {
+    let scheduledHeartBeat = undefined;
+
+    const scheduleHeartbeat = () => {
       // Heartbeat when `padding` seconds remain (converted to milliseconds)
       const interval = (this.getTtl() - padding) * 1000;
-      return wrappedPromise.timeout(interval).catch(() => {
-        if (wrappedPromise.isPending()) {
-          return this.heartbeat().then(poll);
-        }
-        return wrappedPromise;
-      });
+      scheduledHeartBeat = setTimeout(doHeartbeat, interval);
+      // call .unref() so this loop does not keep the runtime alive by itself;
+      // something else should await the passed-in promise (directly or indirectly)
+      scheduledHeartBeat.unref();
     };
 
-    return poll();
+    const doHeartbeat = async () => {
+      try {
+        await this.heartbeat();
+        scheduleHeartbeat();
+      } catch (error) {
+        logger.error('Failed heartbeat for job %s', this.jid, error);
+      }
+    }
+
+    scheduleHeartbeat();
+    return promise.finally(() => clearTimeout(scheduledHeartBeat));
   }
 
   fail(group, message) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inst/qless-js",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",


### PR DESCRIPTION
...to prevent slowly leaking memory and creating junk on heap.

If the input is already a `Bluebird.Promise`, then `(bluebird.)Promise.resolve(promise)` is an identity function, so actions on `wrappedPromise` are the same as on `promise`. Each `.timeout` and `.catch` invoked on a bluebird promise mutates it internally (bluebird does this) while also building new Promise objects which will cause an ever-growing number of internal references as long as this timeout-loop is running (ie. original promise is pending).

This pre-commit behavior grows the memory, albeit very slowly because the allocated bluebird objects in each cycle are tiny. More annoyingly, it makes debugging difficult - after a job that was running for a few days, we have 10k+ promises chained together in the node.js memory dump, almost all of which are created by bluebird's `.timeout` (and are not GC'd because the original promise is still pending).