### PR TITLE
Add support for argument `--inherit-exec-argv`

### DIFF
--- a/bin/qless-js-worker.js
+++ b/bin/qless-js-worker.js
@@ -47,6 +47,7 @@ commander
   .option('-a, --allow-paths', 'Allow paths for job class names')
   .option('-m, --max-memory <max>', 'Maximum memory each process can consume', 'Infinity')
   .option('-t, --set-tmpdir', 'Set tmpdir to be qless worker process workdir')
+  .option('-i, --inherit-exec-argv', 'Pass node flags to worker processes in forking mode')
   .option('--timeout <ms>', 'Set max job lifetime');
 
 const options = commander.parse(process.argv);
@@ -91,6 +92,7 @@ const config = {
     max: getMaxMemory(),
   },
   setTmpdir: options.setTmpdir,
+  inheritExecArgv: options.inheritExecArgv,
   timeout: options.timeout !== undefined ? parseInt(options.timeout, 10) : undefined,
 };
 

--- a/lib/workers/forking.js
+++ b/lib/workers/forking.js
@@ -22,6 +22,9 @@ class Worker {
     this.pool = workerpool.pool(Path.resolve(__dirname, 'forking-workerpool.js'), {
       minWorkers: this.processes,
       maxWorkers: this.processes,
+      forkOpts: config.inheritExecArgv ? {
+        execArgv: process.execArgv,
+      } : undefined,
     });
     this.config = config;
     this.stopped = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inst/qless-js",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",


### PR DESCRIPTION
This makes it so node options like `--max-old-space-size` are passed through to workers in forking mode.